### PR TITLE
Add cpu-microcode detect-plugin.

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -426,7 +426,7 @@ def auto_install_filter(packages):
     KMS).
     '''
     # any package which matches any of those globs will be accepted
-    whitelist = ['bcmwl*', 'pvr-omap*', 'virtualbox-guest*', 'nvidia-*']
+    whitelist = ['bcmwl*', 'pvr-omap*', 'virtualbox-guest*', 'nvidia-*', '*-microcode']
     allow = []
     for pattern in whitelist:
         allow.extend(fnmatch.filter(packages, pattern))

--- a/detect-plugins/cpu-microcode.py
+++ b/detect-plugins/cpu-microcode.py
@@ -24,8 +24,7 @@ def detect(apt_cache):
             for line in file:
                 if line.startswith('vendor_id'):
                     cpu = line.split(':')[1].strip()
-                    return [db.get(cpu)]
+                    if cpu in db:
+                        return [db.get(cpu)]
     except IOError as err:
         logging.debug('could not open /proc/cpuinfo: %s', err)
-
-    return None

--- a/detect-plugins/cpu-microcode.py
+++ b/detect-plugins/cpu-microcode.py
@@ -1,0 +1,31 @@
+# ubuntu-drivers-common custom detect plugin for x86 CPU microcodes
+#
+# Author: Dimitri John Ledkov <dimitri.j.ledkov@intel.com>
+#
+# This plugin detects CPU microcode packages based on pattern matching
+# against the "vendor_id" line in /proc/cpuinfo.
+#
+# To add a new microcode family, simply insert a line into the db
+# variable with the following format:
+#
+# '<Pattern from your cpuinfo output>': '<Name of the driver package>',
+#
+
+import logging
+
+db = {
+    'GenuineIntel': 'intel-microcode',
+    'AuthenticAMD': 'amd64-microcode',
+     }
+
+def detect(apt_cache):
+    try:
+        with open('/proc/cpuinfo') as file:
+            for line in file:
+                if line.startswith('vendor_id'):
+                    cpu = line.split(':')[1].strip()
+                    return [db.get(cpu)]
+    except IOError as err:
+        logging.debug('could not open /proc/cpuinfo: %s', err)
+
+    return None


### PR DESCRIPTION
Whitelist microcode packages for autoinstallation.

Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/ubuntu-drivers-common/+bug/1386257

Signed-off-by: Dimitri John Ledkov <dimitri.j.ledkov@intel.com>