### PR TITLE
Depend on liblocale-gettext-perl for autopkgtest

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
-ubuntu-drivers-common (1:0.4.13) UNRELEASED; urgency=medium
+ubuntu-drivers-common (1:0.4.13) xenial; urgency=medium
 
   * Depend on liblocale-gettext-perl for autopkgtest, forcing it not to be
     dropped during Perl transitions (thereby breaking the fglrx test) due to
     pinning only necessary packages from -proposed.
 
- -- Colin Watson <cjwatson@ubuntu.com>  Tue, 29 Dec 2015 05:20:08 +0000
+ -- Colin Watson <cjwatson@ubuntu.com>  Tue, 29 Dec 2015 05:22:18 +0000
 
 ubuntu-drivers-common (1:0.4.12) xenial; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-drivers-common (1:0.4.13) UNRELEASED; urgency=medium
+
+  * Depend on liblocale-gettext-perl for autopkgtest, forcing it not to be
+    dropped during Perl transitions (thereby breaking the fglrx test) due to
+    pinning only necessary packages from -proposed.
+
+ -- Colin Watson <cjwatson@ubuntu.com>  Tue, 29 Dec 2015 05:20:08 +0000
+
 ubuntu-drivers-common (1:0.4.12) xenial; urgency=medium
 
   [ Alberto Milone ]

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,3 +1,3 @@
 Tests: system
-Depends: ubuntu-drivers-common, apport, python3-gi, gir1.2-umockdev-1.0, umockdev, libgl1-mesa-glx, linux-headers-generic | linux-headers
+Depends: ubuntu-drivers-common, apport, python3-gi, gir1.2-umockdev-1.0, umockdev, libgl1-mesa-glx, linux-headers-generic | linux-headers, liblocale-gettext-perl
 Restrictions: needs-root


### PR DESCRIPTION
This forces it not to be dropped during Perl transitions (thereby breaking
the fglrx test) due to pinning only necessary packages from -proposed.

This corresponds to an upload I just made to xenial.