### PR TITLE
Quirks/quirkinfo.py: Handle UnicodeDecodeError

### DIFF
--- a/Quirks/quirkinfo.py
+++ b/Quirks/quirkinfo.py
@@ -44,7 +44,7 @@ class QuirkInfo:
             try:
                 value = open(os.path.join(self.sys_dir,
                     'class', 'dmi', 'id', item)).read().strip()
-            except (OSError, IOError):
+            except (OSError, IOError, UnicodeDecodeError):
                 value = ''
             self._quirk_info[item] = value
         


### PR DESCRIPTION
On some Dell machine, the /sys/class/dmi/id/board_name is ffffffffffff0a (hex). It means empty.
This makes an error when reading these strings in python3. We can
catch UnicodeDecodeError and ignore this kind of strings.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>