### PR TITLE
gpu-manager: Disable 'nvidiaXineramaInfo' for NVIDIA X driver

### DIFF
--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -2050,6 +2050,7 @@ static bool write_prime_xorg_conf(struct device **devices, int cards_n) {
                 "    Device \"nvidia\"\n"
                 "    Option \"AllowEmptyInitialConfiguration\" \"on\"\n"
                 "    Option \"IgnoreDisplayDevices\" \"CRT\"\n"
+                "    Option \"nvidiaXineramaInfo\" \"False\"\n"
                 "EndSection\n\n",
                (int)(devices[i]->bus),
                (int)(devices[i]->domain),


### PR DESCRIPTION
On X servers with RandR 1.2, disabling "nvidiaXineramaInfo" causes the
NVIDIA X driver to still register its Xinerama implementation but report
a single screen-sized region.