### PR TITLE
Remove remaing upstart pieces

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -37,20 +37,6 @@ override_dh_install:
 	mkdir -p debian/dh-modaliases/usr/share/man/man1
 	pod2man -c Debhelper -r "$(DEB_VERSION)" debhelper/dh_modaliases debian/dh-modaliases/usr/share/man/man1/dh_modaliases.1
 
-	# clean up old upstart conffile for hybrid-detect
-	if [ ! -e debian/ubuntu-drivers-common/usr/bin/hybrid-detect ]; then \
-	    echo "rm_conffile /etc/init/hybrid-gfx.conf 1:0.2.91~" > debian/ubuntu-drivers-common.maintscript; \
-	fi
-
-	# clean up upstart conffile on upgrade on architectures which do not
-	# ship gpu-manager
-	if [ ! -e debian/ubuntu-drivers-common/usr/bin/gpu-manager ]; then \
-	    echo "rm_conffile /etc/init/gpu-manager.conf 1:0.2.91~" >> debian/ubuntu-drivers-common.maintscript; \
-	fi
-
-	# Remove fglrx-pxpress' upstart job
-	echo "rm_conffile /etc/init/amd-config.conf 1:0.2.91.1~" >> debian/ubuntu-drivers-common.maintscript
-
 override_dh_python3:
 	dh_python3 --shebang=/usr/bin/python3
 

--- a/debian/ubuntu-drivers-common.install
+++ b/debian/ubuntu-drivers-common.install
@@ -1,3 +1,2 @@
-etc
 usr
 var

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ extra_data = []
 if '86' in os.uname()[4]:
     subprocess.check_call(["make", "-C", "share/hybrid", "all"])
     extra_data.append(("/usr/bin/", ["share/hybrid/gpu-manager"]))
-    extra_data.append(("/etc/init/", ["share/hybrid/gpu-manager.conf"]))
     extra_data.append(("/lib/systemd/system/", ["share/hybrid/gpu-manager.service"]))
     extra_data.append(("/sbin/", ["share/hybrid/u-d-c-print-pci-ids"]))
     extra_data.append(("/lib/udev/rules.d/", ["share/hybrid/71-u-d-c-gpu-detection.rules"]))
@@ -31,7 +30,6 @@ setup(
     packages=["NvidiaDetector", "Quirks", "UbuntuDrivers"],
     data_files=[("/usr/share/ubuntu-drivers-common/", ["share/obsolete", "share/fake-devices-wrapper"]),
                 ("/var/lib/ubuntu-drivers-common/", []),
-                ("/etc/", []),
                 ("/usr/share/ubuntu-drivers-common/quirks", glob.glob("quirks/*")),
                 ("/usr/share/ubuntu-drivers-common/detect", glob.glob("detect-plugins/*")),
                 ("/usr/share/doc/ubuntu-drivers-common", ['README']),

--- a/share/hybrid/gpu-manager.conf
+++ b/share/hybrid/gpu-manager.conf
@@ -1,7 +1,0 @@
-start on (starting lightdm
-          or starting gdm
-          or starting kdm
-          or starting xdm
-          or starting lxdm)
-task
-exec gpu-manager --log /var/log/gpu-manager.log


### PR DESCRIPTION
We almost don't have any more upstart scripts in /etc/init on a default Ubuntu Bionic install.  This is one of 6 items remaining there.

Thanks!