### PR TITLE
gpu-manager.c: use runtime D3 instead of DSM to disable Nvidia GPU

### DIFF
--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -3201,7 +3201,7 @@ static bool enable_prime(const char *prime_settings,
      * Note: the force-dgpu-on hook overrides this, and always
      *       forces the dGPU to be on
      */
-    prime_action_on = prime_is_action_on();
+    prime_action_on = force_dgpu_on ? false : prime_is_action_on();
 
     if (prime_action_on) {
         if (!alternative->nvidia_enabled) {

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -1266,8 +1266,6 @@ static bool get_custom_hook_name(const char *pattern, char **path)
             break;
         }
         closedir(dir);
-        if (!*path)
-            return false;
     }
     else {
         *path = malloc(strlen(custom_hook_path) + strlen(pattern) + 2);
@@ -1285,9 +1283,9 @@ static bool has_custom_hook(const char *filename)
 {
     _cleanup_free_ char *path = NULL;
 
-    bool status = get_custom_hook_name(filename, &path);
+    get_custom_hook_name(filename, &path);
 
-    return (status ? exists_not_empty(path) : false);
+    return exists_not_empty(path);
 }
 
 
@@ -1306,16 +1304,6 @@ static bool has_hybrid_performance_conf_file(void)
 static bool has_hybrid_power_saving_conf_file(void)
 {
     return has_custom_hook("hybrid-power-saving");
-}
-
-
-static bool has_force_dgpu_on_file(void)
-{
-    _cleanup_free_ char *path = NULL;
-    bool result = get_custom_hook_name("force-dgpu-on", &path);
-    fprintf(log_handle, "force-dgpu-on: %s\n", path);
-
-    return result;
 }
 
 
@@ -2126,6 +2114,7 @@ static bool prime_is_action_on() {
 
 static bool prime_set_discrete(int mode) {
     _cleanup_fclose_ FILE *file = NULL;
+
     file = fopen(bbswitch_path, "w");
     if (!file)
         return false;
@@ -3138,12 +3127,6 @@ static bool enable_prime(const char *prime_settings,
     bool prime_discrete_on = false;
     bool prime_action_on = false;
 
-    /* See if there is a custom hook to disable power saving */
-    bool force_dgpu_on = has_force_dgpu_on_file();
-
-    fprintf(log_handle, "force-dgpu-on hook %s\n",
-            (force_dgpu_on ? "on" : "off"));
-
     /* We only support Lightdm and GDM at this time */
     if (!(is_lightdm_default() || is_gdm_default() || is_sddm_default())) {
         fprintf(log_handle, "Neither Lightdm nor GDM is the default display "
@@ -3183,7 +3166,7 @@ static bool enable_prime(const char *prime_settings,
         }
     }
 
-    if (!bbswitch_loaded && !force_dgpu_on) {
+    if (!bbswitch_loaded) {
         /* Try to load bbswitch */
         /* opts="`/sbin/get-quirk-options`"
         /sbin/modprobe bbswitch load_state=-1 unload_state=1 "$opts" || true */
@@ -3194,14 +3177,9 @@ static bool enable_prime(const char *prime_settings,
     }
 
     /* Get the current status from bbswitch */
-    if (!force_dgpu_on)
-        prime_discrete_on = !bbswitch_status ? true : prime_is_discrete_nvidia_on();
-
-    /* Get the current settings for discrete
-     * Note: the force-dgpu-on hook overrides this, and always
-     *       forces the dGPU to be on
-     */
-    prime_action_on = force_dgpu_on ? false : prime_is_action_on();
+    prime_discrete_on = !bbswitch_status ? true : prime_is_discrete_nvidia_on();
+    /* Get the current settings for discrete */
+    prime_action_on = prime_is_action_on();
 
     if (prime_action_on) {
         if (!alternative->nvidia_enabled) {
@@ -3245,12 +3223,6 @@ static bool enable_prime(const char *prime_settings,
         }
     }
 
-    /* No need for any further action if we are since we want to keep
-     * the dGPU on
-     */
-    if (force_dgpu_on)
-        goto end;
-
     /* This means we need to call bbswitch
      * to take action
      */
@@ -3271,7 +3243,6 @@ static bool enable_prime(const char *prime_settings,
         }
     }
 
-end:
     return true;
 }
 

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -2144,17 +2144,8 @@ static bool prime_set_discrete(int mode) {
 static bool prime_enable_discrete() {
     bool status = false;
 
-    /* See if there is a custom hook to disable power saving */
-    bool force_dgpu_on = has_force_dgpu_on_file();
-
-    /* No need to set bbswitch if we want to keep
-    * the dGPU on
-    */
-    if (!force_dgpu_on)
-        /* Set bbswitch */
-        status = prime_set_discrete(1);
-    else
-        status = true;
+    /* Set bbswitch */
+    status = prime_set_discrete(1);
 
     /* Load the module */
     if (status) {
@@ -2169,13 +2160,11 @@ static bool prime_enable_discrete() {
     return status;
 }
 
+
 /* Power off the NVIDIA discrete card */
 static bool prime_disable_discrete(const int nvidia_version) {
     bool status = false;
     char command[100];
-
-    /* See if there is a custom hook to disable power saving */
-    bool force_dgpu_on = has_force_dgpu_on_file();
 
     /* Disable persistence mode (just in case) */
     sprintf(command, "LD_LIBRARY_PATH=\"/usr/lib/nvidia-%d\" /usr/bin/nvidia-smi -pm 0",
@@ -2195,12 +2184,9 @@ static bool prime_disable_discrete(const int nvidia_version) {
     /* Unload the module */
     status = unload_module("nvidia");
 
-    /* Set bbswitch, but No need for any further action if we want to keep
-    * the dGPU on
-    */
-    if (status && !force_dgpu_on) {
-       status = prime_set_discrete(0);
-    }
+    /* Set bbswitch */
+    if (status)
+        status = prime_set_discrete(0);
 
     return status;
 }
@@ -3201,7 +3187,7 @@ static bool enable_prime(const char *prime_settings,
         }
     }
 
-    if (!bbswitch_loaded) {
+    if (!bbswitch_loaded && !force_dgpu_on) {
         /* Try to load bbswitch */
         /* opts="`/sbin/get-quirk-options`"
         /sbin/modprobe bbswitch load_state=-1 unload_state=1 "$opts" || true */
@@ -3212,7 +3198,8 @@ static bool enable_prime(const char *prime_settings,
     }
 
     /* Get the current status from bbswitch */
-    prime_discrete_on = !bbswitch_status ? true : prime_is_discrete_nvidia_on();
+    if (!force_dgpu_on)
+        prime_discrete_on = !bbswitch_status ? true : prime_is_discrete_nvidia_on();
 
     /* Get the current settings for discrete
      * Note: the force-dgpu-on hook overrides this, and always
@@ -3262,6 +3249,11 @@ static bool enable_prime(const char *prime_settings,
         }
     }
 
+    /* No need for any further action if we are since we want to keep
+     * the dGPU on
+     */
+    if (force_dgpu_on)
+        goto end;
 
     /* This means we need to call bbswitch
      * to take action

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -1312,12 +1312,8 @@ static bool has_hybrid_power_saving_conf_file(void)
 static bool has_force_dgpu_on_file(void)
 {
     _cleanup_free_ char *path = NULL;
-    bool result = false;
-    if (get_custom_hook_name("force-dgpu-on", &path)) {
-        result = is_file(path);
-        if (result)
-            fprintf(log_handle, "force-dgpu-on: %s\n", path);
-    }
+    bool result = get_custom_hook_name("force-dgpu-on", &path);
+    fprintf(log_handle, "force-dgpu-on: %s\n", path);
 
     return result;
 }

--- a/tests/gpu-manager.py
+++ b/tests/gpu-manager.py
@@ -13387,9 +13387,9 @@ EndSection
 
         # Check the variables
 
-        # Check quirks - they will be ignored, though, as load_bbswitch is skipped
-        self.assertTrue(gpu_test.matched_quirk)
-        self.assertTrue(gpu_test.loaded_with_args)
+        # Check quirks - ignore, as load_bbswitch is skipped
+        self.assertFalse(gpu_test.matched_quirk)
+        self.assertFalse(gpu_test.loaded_with_args)
 
         # Check if laptop
         self.assertTrue(gpu_test.requires_offloading)

--- a/tests/gpu-manager.py
+++ b/tests/gpu-manager.py
@@ -13417,9 +13417,9 @@ EndSection
         # Has changed
         self.assertTrue(gpu_test.has_changed)
         self.assertTrue(gpu_test.has_removed_xorg)
-        self.assertTrue(gpu_test.has_regenerated_xorg)
+        self.assertFalse(gpu_test.has_regenerated_xorg)
         self.assertTrue(gpu_test.has_force_dgpu_on_hook)
-        self.assertFalse(gpu_test.has_selected_driver)
+        self.assertTrue(gpu_test.has_selected_driver)
 
         # No further action is required
         self.assertFalse(gpu_test.has_not_acted)


### PR DESCRIPTION
New Optimus machines no longer use ACPI DSM to disable their GPU.
Instead, they just put the GPU to D3cold when it's not in use.

DSM method doesn't work well with port pm. Once DSM gets called, the
entire machine hangs. We should simply stop using DSM.

We can use the bbswitch_dev to enable RTD3 for Nvidia GPU.
The current bbswitch_dev doesn't handle bridge D3, so we need to use [1]
to make nvidia.ko happy.

[1] Bumblebee-Project/bbswitch#166