### PR TITLE
Free only drivers

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -253,7 +253,7 @@ def _get_db_name(syspath, alias):
                   alias, vendor, model)
     return (vendor, model)
 
-def system_driver_packages(apt_cache=None, sys_path=None):
+def system_driver_packages(apt_cache=None, sys_path=None, freeonly=False):
     '''Get driver packages that are available for the system.
     
     This calls system_modaliases() to determine the system's hardware and then
@@ -263,6 +263,9 @@ def system_driver_packages(apt_cache=None, sys_path=None):
     If you already have an apt.Cache() object, you should pass it as an
     argument for efficiency. If not given, this function creates a temporary
     one by itself.
+
+    If freeonly is set to True, only free packages (from main and universe) are
+    considered
 
     Return a dictionary which maps package names to information about them:
 
@@ -294,6 +297,8 @@ def system_driver_packages(apt_cache=None, sys_path=None):
     packages = {}
     for alias, syspath in modaliases.items():
         for p in packages_for_modalias(apt_cache, alias):
+            if freeonly and not _is_package_free(p):
+                continue
             packages[p.name] = {
                     'modalias': alias,
                     'syspath': syspath,
@@ -448,7 +453,7 @@ def system_gpgpu_driver_packages(apt_cache=None, sys_path=None):
     return packages
 
 
-def system_device_drivers(apt_cache=None, sys_path=None):
+def system_device_drivers(apt_cache=None, sys_path=None, freeonly=False):
     '''Get by-device driver packages that are available for the system.
     
     This calls system_modaliases() to determine the system's hardware and then
@@ -459,6 +464,9 @@ def system_device_drivers(apt_cache=None, sys_path=None):
     If you already have an apt.Cache() object, you should pass it as an
     argument for efficiency. If not given, this function creates a temporary
     one by itself.
+
+    If freeonly is set to True, only free packages (from main and universe) are
+    considered
 
     Return a dictionary which maps devices to available drivers:
 
@@ -503,7 +511,8 @@ def system_device_drivers(apt_cache=None, sys_path=None):
         apt_cache = apt.Cache()
 
     # copy the system_driver_packages() structure into the by-device structure
-    for pkg, pkginfo in system_driver_packages(apt_cache, sys_path).items():
+    for pkg, pkginfo in system_driver_packages(apt_cache, sys_path,
+                                               freeonly=freeonly).items():
         if 'syspath' in pkginfo:
             device_name = pkginfo['syspath']
         else:

--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -166,9 +166,9 @@ def _is_package_free(pkg):
     # it would be better to check the actual license, as we do not have
     # the component for third-party packages; but this is the best we can do
     # at the moment
-    if pkg.candidate.section.startswith('restricted') or \
-            pkg.candidate.section.startswith('multiverse'):
-        return False
+    for o in pkg.candidate.origins:
+        if o.component in ('restricted','multiverse'):
+            return False
     return True
 
 def _is_package_from_distro(pkg):
@@ -375,26 +375,6 @@ def _get_headless_no_dkms_metapackage(pkg, apt_cache):
         pass
 
     return metapackage
-
-def _is_package_free(pkg):
-    assert pkg.candidate is not None
-    # it would be better to check the actual license, as we do not have
-    # the component for third-party packages; but this is the best we can do
-    # at the moment
-    if pkg.candidate.section.startswith('restricted') or \
-            pkg.candidate.section.startswith('multiverse'):
-        return False
-    return True
-
-def _is_package_from_distro(pkg):
-    if pkg.candidate is None:
-        return False
-
-    for o in pkg.candidate.origins:
-        if o.origin == 'Ubuntu':
-            return True
-    return False
-
 
 
 def system_gpgpu_driver_packages(apt_cache=None, sys_path=None):

--- a/tests/run
+++ b/tests/run
@@ -30,6 +30,8 @@ def usage():
     '\n  -i, --input=<filename>', '\tthe xorg.conf used for the tests.'
     
     '\n  -h, --help', '\t\t\thelp page.'
+
+    '\n  [Test ...]', '\t\t\tList of tests, the entire testsuite will be executed otherwise.'
     ]
     print(''.join(instructionsList))
 
@@ -69,10 +71,13 @@ def main():
     settingsFile.close()
         
     # run all tests in our directory
-    suite = unittest.TestLoader().loadTestsFromNames(
-        [t[:-3] for t in os.listdir(os.path.dirname(__file__)) 
-         if t.endswith('.py') and t not in ['settings.py', '__init__.py'] and not
-         (t == 'gpu-manager.py' and '86' not in os.uname()[4])])
+    if args:
+        suite = unittest.TestLoader().loadTestsFromNames(args)
+    else:
+        suite = unittest.TestLoader().loadTestsFromNames(
+            [t[:-3] for t in os.listdir(os.path.dirname(__file__))
+            if t.endswith('.py') and t not in ['settings.py', '__init__.py'] and not
+            (t == 'gpu-manager.py' and '86' not in os.uname()[4])])
     res = unittest.TextTestRunner(verbosity=2).run(suite)
     return len(res.errors) + len(res.failures)
 

--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -52,12 +52,15 @@ def create_parser():
         # Python 3.5.2 in Xenial will crash when matching square brackets
         parser.add_argument("--gpgpu", const='default', nargs='?', metavar='driver{:version}{,driver{:version}}', help="Install GPGPU drivers")
 
+    parser.add_argument('--free-only', action="store_true", default=False,
+                        help='Only consider free packages')
     return parser
 
 def command_list(args):
     '''Show all driver packages which apply to the current system.'''
 
-    packages = UbuntuDrivers.detect.system_driver_packages(sys_path=sys_path)
+    packages = UbuntuDrivers.detect.system_driver_packages(
+        sys_path=sys_path, freeonly=args.free_only)
     if packages:
         print('\n'.join(packages))
 
@@ -77,7 +80,8 @@ def list_gpgpu(args):
 def command_devices(args):
     '''Show all devices which need drivers, and which packages apply to them.'''
 
-    drivers = UbuntuDrivers.detect.system_device_drivers(sys_path=sys_path)
+    drivers = UbuntuDrivers.detect.system_device_drivers(
+        sys_path=sys_path, freeonly=args.free_only)
     for device, info in drivers.items():
         print('== %s ==' % device)
         for k, v in info.items():
@@ -107,7 +111,8 @@ def command_install(args):
 
     cache = apt.Cache()
 
-    packages = UbuntuDrivers.detect.system_driver_packages(cache, sys_path)
+    packages = UbuntuDrivers.detect.system_driver_packages(
+        cache, sys_path, freeonly=args.free_only)
     packages = UbuntuDrivers.detect.auto_install_filter(packages)
     if not packages:
         print('No drivers found for installation.')
@@ -192,7 +197,8 @@ def command_debug(args):
     print('=== log messages from detection ===')
     aliases = UbuntuDrivers.detect.system_modaliases()
     cache = apt.Cache()
-    packages = UbuntuDrivers.detect.system_driver_packages(cache, sys_path)
+    packages = UbuntuDrivers.detect.system_driver_packages(
+        cache, sys_path, freeonly=args.free_only)
     auto_packages = UbuntuDrivers.detect.auto_install_filter(packages)
 
     print('=== modaliases in the system ===')


### PR DESCRIPTION
This branch adds a --free-only option to ubuntu-drivers to only consider free drivers.

The fake archive of the test suite had to be modified to support free (main and universe) and non-free components. 
Tests have been added to cover this option.

The function _is_package_free has been fixed.