### PR TITLE
Fix nvidia detector

### DIFF
--- a/NvidiaDetector/alternatives.py
+++ b/NvidiaDetector/alternatives.py
@@ -20,9 +20,9 @@
 #       MA 02110-1301, USA.
 
 import os
-import re
 import subprocess
 from subprocess import Popen, PIPE, CalledProcessError
+
 
 class MultiArchUtils(object):
 
@@ -56,6 +56,7 @@ class MultiArchUtils(object):
     def get_other_alternative_name(self):
         return self._get_alternative_name_from_arch(self._other_arch)
 
+
 class Alternatives(object):
 
     def __init__(self, master_link):
@@ -85,7 +86,6 @@ class Alternatives(object):
     def get_current_alternative(self):
         '''Get the alternative in use'''
         dev_null = open('/dev/null', 'w')
-        current_alternative = None
         p1 = Popen([self._command, '--query', self._master_link],
                    stdout=PIPE, stderr=dev_null, universal_newlines=True)
         p = p1.communicate()[0]
@@ -151,7 +151,6 @@ class Alternatives(object):
     def resolve_module_alias(self, alias):
         '''Get the 1st kernel module name matching an alias'''
         dev_null = open('/dev/null', 'w')
-        current_alternative = None
         p1 = Popen(['modprobe', '--resolve-alias', alias], stdout=PIPE,
                    stderr=dev_null, universal_newlines=True)
         p = p1.communicate()[0]

--- a/NvidiaDetector/nvidiadetector.py
+++ b/NvidiaDetector/nvidiadetector.py
@@ -76,7 +76,7 @@ class NvidiaDetection(object):
         if printonly:
             self.printSelection()
         else:
-            self.selectDriver()
+            print(self.selectDriver())
 
     def __get_name_from_value(self, value):
         '''Get the name of a driver from its corresponding integer'''
@@ -407,7 +407,7 @@ class NvidiaDetection(object):
         else:
             # print driver
             sys.stdout.flush()
-            print('none')
+            print(driver)
 
 # def usage():
 #     instructionsList = ['The only accepted parameters are:'

--- a/NvidiaDetector/nvidiadetector.py
+++ b/NvidiaDetector/nvidiadetector.py
@@ -385,11 +385,14 @@ class NvidiaDetection(object):
         notInstalled = a list of the obsolete drivers which are not
                        installed
         '''
-        installedPackage = None
+
+        #  FIXME: Commented code to make static tests pass
+        #         This piece of code sets installedPackage which is not used anywhere
+        # installedPackage = None
         notInstalled = self.checkpkg(self.oldPackages)
-        for package in self.oldPackages:
-            if package not in notInstalled:
-                installedPackage = package
+        # for package in self.oldPackages:
+        #     if package not in notInstalled:
+        #        installedPackage = package
         return (len(notInstalled) != len(self.oldPackages))
 
     def printSelection(self):

--- a/NvidiaDetector/nvidiadetector.py
+++ b/NvidiaDetector/nvidiadetector.py
@@ -1,3 +1,7 @@
+#!/usr/bin/python3
+
+''' Detection tool for nVidia graphics cards '''
+
 #
 #       nvidiadetector.py
 #
@@ -349,15 +353,15 @@ class NvidiaDetection(object):
         p = p1.communicate()[0]
         c = p.split('\n')
         for line in c:
-            if line.find('\tinstall') != -1:#the relevant lines
+            if line.find('\tinstall') != -1:    # the relevant lines
                 lines.append(line.split('\t')[0])
-        if self.isstr(pkglist) == True:#if it is a string
+        if isinstance(pkglist, str):            # if it is a string
             try:
                 if lines.index(pkglist):
                     pass
             except ValueError:
                 notinstalled.append(pkglist)
-        else:#if it is a list
+        else:       # if it is a list
             for pkg in pkglist:
                 try:
                     if lines.index(pkg):
@@ -366,18 +370,6 @@ class NvidiaDetection(object):
                     notinstalled.append(pkg)
 
         return notinstalled
-
-    def isstr(self, elem):
-        if bytes is str:
-            #Python 2
-            string_types = basestring
-        else:
-            #Python 3
-            string_types = str
-        return isinstance(elem, string_types)
-
-    def islst(self, elem):
-        return isinstance(elem, (tuple, list))
 
     def getDrivers(self):
         '''

--- a/NvidiaDetector/nvidiadetector.py
+++ b/NvidiaDetector/nvidiadetector.py
@@ -110,21 +110,28 @@ class NvidiaDetection(object):
         self.cards = []
         p1 = Popen(['lspci', '-n'], stdout=PIPE, universal_newlines=True)
         p = p1.communicate()[0].split('\n')
+
+        # Display controllers are device class 03
+        # There are 4 subclasses
+        #   00	VGA compatible controller
+        #   01	XGA compatible controller
+        #   02	3D controller
+        #   80	Display controller
         # if you don't have an nvidia card, fake one for debugging
         # p = ['00:02.0 0300: 10DE:03DE (rev 02)']
-        indentifier1 = re.compile(r'.*0300: *(.+):(.+) \(.+\)')
-        indentifier2 = re.compile(r'.*0300: *(.+):(.+)')
+        indentifier1 = re.compile(r'.*03(80|0[0-2]): *(?P<vendor>.+):(?P<device>.+) \(.+\)')
+        indentifier2 = re.compile(r'.*03(80|0[0-2]): *(?P<vendor>.+):(?P<device>.+)')
         for line in p:
             m1 = indentifier1.match(line)
             m2 = indentifier2.match(line)
             if m1:
-                id1 = m1.group(1).strip().lower()
-                id2 = m1.group(2).strip().lower()
+                id1 = m1.group("vendor").strip().lower()
+                id2 = m1.group("device").strip().lower()
                 id = id1 + ':' + id2
                 self.cards.append(id)
             elif m2:
-                id1 = m2.group(1).strip().lower()
-                id2 = m2.group(2).strip().lower()
+                id1 = m2.group("vendor").strip().lower()
+                id2 = m2.group("device").strip().lower()
                 id = id1 + ':' + id2
                 self.cards.append(id)
 

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -57,7 +57,6 @@ class TestStatic(unittest.TestCase):
             ".bzr", ".git", "__pycache__", "debian",
             # Project dirs ignored for the moment
             "Quirks",
-            "NvidiaDetector",
             ]
         # List of files to ignore with ../ stripped from the beginning of the path
         ignore_files = [


### PR DESCRIPTION
Make nvidia-detector work again.

Fixed regexp to match all sub classes of display devices.
Actually print the name of the selected driver.
Removed python2 code since it runs with python3.
Commented out unused code.
Enabled static tests.