### PR TITLE
gpu-manager: set power to "auto" in PRIME "ONDEMAND" mode; minor cleanups

### DIFF
--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -1704,7 +1704,7 @@ static bool enable_prime(const char *prime_settings,
         create_offload_serverlayout();
         /* Remove the OutputClass */
         remove_prime_outputclass();
-        disable_power_management(device);
+        enable_power_management(device);
         if (!is_module_loaded("nvidia"))
             load_module("nvidia");
     }

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -896,7 +896,7 @@ static bool is_connector_connected(const char *connector) {
 
 /* Count the number of outputs connected to the card */
 int count_connected_outputs(const char *device_name) {
-    char name[50];
+    char name[PATH_MAX];
     struct dirent *dp;
     DIR *dfd;
     int connected_outputs = 0;
@@ -915,7 +915,8 @@ int count_connected_outputs(const char *device_name) {
                     drm_dir, dp->d_name);
         else {
             /* Open the file for the connector */
-            sprintf(name, "%s/%s/status", drm_dir, dp->d_name);
+            snprintf(name, sizeof(name), "%s/%s/status", drm_dir, dp->d_name);
+            name[sizeof(name) - 1] = 0;
             if (is_connector_connected(name)) {
                 fprintf(log_handle, "output %d:\n", connected_outputs);
                 fprintf(log_handle, "\t%s\n", dp->d_name);
@@ -935,7 +936,7 @@ int count_connected_outputs(const char *device_name) {
 static int has_driver_connected_outputs(const char *driver) {
     DIR *dir;
     struct dirent* dir_entry;
-    char path[20];
+    char path[PATH_MAX];
     int fd = 1;
     drmVersionPtr version;
     int connected_outputs = 0;
@@ -954,6 +955,7 @@ static int has_driver_connected_outputs(const char *driver) {
             continue;
 
         snprintf(path, sizeof(path), "%s/%s", dri_dir, dir_entry->d_name);
+        path[sizeof(path) - 1] = 0;
         fd = open(path, O_RDWR);
         if (fd) {
             if ((version = drmGetVersion(fd))) {


### PR DESCRIPTION
We could possibly go further and have power set to "auto" for PRIME "ON" mode as well, but I didn't do that in this patch series since I wasn't sure if there was a particular reason it's set to "on" in that mode. (e.g. to avoid an interaction problem with other power management tools like bbswitch)