### PR TITLE
debian/rules: don't recurse deleted folders

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -47,5 +47,5 @@ override_dh_clean:
 	rm -rf build
 	rm -rf *.egg-info
 	rm -f debian/ubuntu-drivers-common.maintscript
-	find $(CURDIR) -name "__pycache__" -exec rm -rf "{}" \;
+	find $(CURDIR) -name "__pycache__" -prune -exec rm -rf "{}" \;
 	dh_clean


### PR DESCRIPTION
Building locally after interrupting the build results in it failing with:

    find /Projects/ubuntu-drivers-common -name "__pycache__" -exec rm -rf "{}" \;
    find: ‘/Projects/ubuntu-drivers-common/__pycache__’: No such file or directory
    find: ‘/Projects/ubuntu-drivers-common/tests/__pycache__’: No such file or directory
    find: ‘/Projects/ubuntu-drivers-common/UbuntuDrivers/__pycache__’: No such file or directory
    find: ‘/Projects/ubuntu-drivers-common/Quirks/__pycache__’: No such file or directory
    make[1]: *** [debian/rules:50: override_dh_clean] Error 1

Don't search in these folders, since they're going to be deleted.

Fixes: ce06fef5e5410 ("debian/rules: make sure to remove \_\_pycache__")