### PR TITLE
gpu-manager: delete offload configuration file on NVIDIA single-GPU systems

### DIFF
--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -2271,7 +2271,9 @@ int main(int argc, char *argv[]) {
             }
         }
         else if (boot_vga_vendor_id == NVIDIA) {
-            fprintf(log_handle, "Nothing to do\n");
+            if (remove_offload_serverlayout() == -ENOENT) {
+                fprintf(log_handle, "Nothing to do\n");
+            }
         }
     }
     else if (cards_n > 1) {

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -1402,20 +1402,29 @@ static bool create_offload_serverlayout(void) {
     return false;
 }
 
-static void remove_prime_outputclass(void) {
-    char xorg_d_custom[PATH_MAX];
-    snprintf(xorg_d_custom, sizeof(xorg_d_custom), "%s/11-nvidia-prime.conf",
-            xorg_conf_d_path);
-    fprintf(log_handle, "Removing %s\n", xorg_d_custom);
-    unlink(xorg_d_custom);
+/* Attempt to remove a file named "name" in xorg_conf_d_path. Returns 0 if the
+ * file is successfully removed, or -errno on failure. */
+static int remove_xorg_d_custom_file(const char *name) {
+    char path[PATH_MAX];
+    struct stat st;
+
+    snprintf(path, sizeof(path), "%s/%s", xorg_conf_d_path, name);
+    if (stat(path, &st) == 0) {
+        fprintf(log_handle, "Removing %s\n", path);
+        if (unlink(path) == 0) {
+            return 0;
+        }
+    }
+
+    return -errno;
 }
 
-static void remove_offload_serverlayout(void) {
-    char xorg_d_custom[PATH_MAX];
-    snprintf(xorg_d_custom, sizeof(xorg_d_custom), "%s/11-nvidia-offload.conf",
-            xorg_conf_d_path);
-    fprintf(log_handle, "Removing %s\n", xorg_d_custom);
-    unlink(xorg_d_custom);
+static int remove_prime_outputclass(void) {
+    return remove_xorg_d_custom_file("11-nvidia-prime.conf");
+}
+
+static int remove_offload_serverlayout(void) {
+    return remove_xorg_d_custom_file("11-nvidia-offload.conf");
 }
 
 static bool manage_power_management(const struct device *device, bool enabled) {


### PR DESCRIPTION
On systems with only an NVIDIA GPU present, the render offload configuration file generated by gpu-manager when "on-demand" mode is enabled prevents X from starting, as it explicitly configures the NVIDIA GPU to drive a GPU screen with a non-NVIDIA protocol screen. This could happen if a muxed hybrid system was prevoiusly configured in hybrid mode with render offloading and then reconfigured in dGPU-only mode, or if a boot disk is migrated from a hybrid system to a non-hybrid NVIDIA-only system.

In order to allow X to continue working when on-demand mode is configured on an NVIDIA-only system, delete the 11-nvidia-offload.conf file if it exists. The on-demand configuration in /etc/prime-discrete is left in place, allowing 11-nvidia-offload.conf to be generated again if booting to a hybrid graphics system again.