### PR TITLE
find_reverse_deps: Use exact matching with both installed and candidate

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -907,18 +907,22 @@ def find_reverse_dependencies(apt_cache, package, prefix):
     '''Return the reverse dependencies for a package'''
     # prefix to restrict the searching
     # package we want reverse dependencies for
-    deps = []
+    deps = set()
     for pkg in apt_cache:
-        if (pkg.name.startswith(prefix)):
-            try:
-                dependencies = apt_cache[pkg.name].candidate.\
-                         record['Depends']
-            except KeyError:
-                continue
+        if pkg.name.startswith(prefix):
+            dependencies = []
+            if pkg.candidate:
+                dependencies.extend(pkg.candidate.dependencies)
+            if pkg.installed:
+                dependencies.extend(pkg.installed.dependencies)
 
-            if package in dependencies:
-                deps.append(pkg.name)
-    return deps
+            for ordep in dependencies:
+                for dep in ordep:
+                    if dep.rawtype != 'Depends':
+                        continue
+                    if dep.name == package:
+                        deps.add(pkg.name)
+    return list(deps)
 
 
 def get_linux_image_from_meta(apt_cache, pkg):

--- a/UbuntuDrivers/kerneldetection.py
+++ b/UbuntuDrivers/kerneldetection.py
@@ -57,22 +57,27 @@ class KernelDetection(object):
     def _find_reverse_dependencies(self, package, prefix):
         # prefix to restrict the searching
         # package we want reverse dependencies for
-        deps = []
+        deps = set()
         for pkg in self.apt_cache:
             if (pkg.name.startswith(prefix) and
                     'extra' not in pkg.name and
-                    self.apt_cache[pkg.name].is_installed or
-                    self.apt_cache[pkg.name].marked_install):
+                    pkg.is_installed or
+                    pkg.marked_install):
 
-                try:
-                    dependencies = self.apt_cache[pkg.name].candidate.\
-                             record['Depends']
-                except KeyError:
-                    continue
+                dependencies = []
+                if pkg.candidate:
+                    dependencies.extend(pkg.candidate.dependencies)
+                if pkg.installed:
+                    dependencies.extend(pkg.installed.dependencies)
 
-                if package in dependencies:
-                    deps.append(pkg.name)
-        return deps
+                for ordep in dependencies:
+                    for dep in ordep:
+                        if dep.rawtype != 'Depends':
+                            continue
+                        if dep.name == package:
+                            deps.add(pkg.name)
+
+        return list(deps)
 
     def _get_linux_flavour(self, candidates, image):
         pattern = re.compile(r'linux-image-([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-(.+)')


### PR DESCRIPTION
On Ubuntu livecd, we may have packages that are installed, but have
new candidates. Or those that are installed and cannot be installed
again.

Consider a case where and old iso boots into
linux-image-5.4.0-25-generic, yet linux-image-5.4.0-26-generic is
available. There is internet, and apt update was executed. In such
situation, linux-meta-package discovery was failing, because there
were no longer any candidates that depend on the old 25 abi, and only
metas that depend on 26.

Also, I switched from vague matching across an unparsed raw Depends
string, to iterating the parsed depedencies instead, such that
matching is exact. This prevents false positive find in case we have
non-unique suffixes, i.e. linux-modules-nvidia-440-lowlatency &
linux-modules-nvidia-440-lowlatency-hwe-20.04. A reverse-dep search
for one, must not find the other one.

I fixed this in both funcations that try to hunt for
reverse-dependencies. Maybe the two functions can be unified, with
like kwarg filter= to allow additional filtering as required in the
kerneldetect case vs detect case.

With this changes in place I can see that ubuntu-drivers list
correctly resolves for modules to be provided by l-r-m meta-packages,
instead of dkms.