### PR TITLE
checking supported-gpus.json to see whether the gpu is runtime pm supported

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -51,6 +51,7 @@ Depends: ${python3:Depends},
  usbutils,
  alsa-utils,
  kmod | module-init-tools,
+ jq,
 Suggests: python3-aptdaemon.pkcompat
 Replaces: nvidia-common (<< 1:0.2.46), jockey-common, jockey-gtk, jockey-kde
 Conflicts: nvidia-common (<< 1:0.2.46), jockey-common, jockey-gtk, jockey-kde


### PR DESCRIPTION
gpu-manager.c: checking supported-gpus.json to see whether the gpu is runtime pm supported
debian/control: depend on jq