### PR TITLE
fix segmentation fault in json_find_feature_in_array

### DIFF
--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -1843,7 +1843,7 @@ static bool json_find_feature_in_array(char* feature, json_value* value)
     fprintf(log_handle, "Looking for availability of \"%s\" feature\n", feature);
     for (x = 0; x < length; x++) {
         /* fprintf(log_handle, "feature string: %s\n", value->u.array.values[x]->u.string.ptr); */
-        if (strcmp(value->u.object.values[x].value->u.string.ptr, feature) == 0) {
+        if (strcmp(value->u.array.values[x]->u.string.ptr, feature) == 0) {
             fprintf(log_handle, "\"%s\" feature found\n", feature);
             return true;
         }


### PR DESCRIPTION
Program received signal SIGSEGV, Segmentation fault.
json_find_feature_in_array (feature=0x55555556216c "runtimepm", value=0x55555561c070) at gpu-manager.c:1846
1846	gpu-manager.c: No such file or directory.
(gdb) bt
#0  json_find_feature_in_array (feature=0x55555556216c "runtimepm", value=0x55555561c070) at gpu-manager.c:1846
#1  0x000055555555ba69 in json_find_feature_in_object (feature=0x55555556216c "runtimepm", value=0x55555561bfe0) at gpu-manager.c:1889
#2  0x000055555555bfa1 in is_nv_runtimepm_supported (nv_device_id=7862) at gpu-manager.c:2022
#3  0x000055555555d614 in main (argc=1, argv=0x7fffffffe518) at gpu-manager.c:2510
