### PR TITLE
releasing package ubuntu-drivers-common version 1:0.8.6.3~0.20.04.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-drivers-common (1:0.8.6.3~0.20.04.2) focal; urgency=medium
+
+  * Skip tests on riscv64, replacing powerpc which is no longer part of
+    focal. Thus make ubuntu-drivers-common available on focal on
+    riscv64. LP: #1912202
+
+ -- Dimitri John Ledkov <xnox@ubuntu.com>  Mon, 18 Jan 2021 22:22:29 +0000
+
 ubuntu-drivers-common (1:0.8.6.3~0.20.04.1) focal; urgency=medium
 
   * Backport 1:0.8.6.3 (LP: #1904583).

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ override_dh_auto_install:
 override_dh_auto_test:
 ifeq (, $(findstring nocheck, $(DEB_BUILD_OPTIONS)))
 	$(call py3sdo, setup.py egg_info)
-	set -e; $(foreach py, $(shell py3versions -r), PATH=$$PATH:/sbin:/usr/sbin PYTHONPATH=. $(py) -B tests/run || [ "$(DEB_HOST_ARCH)" = powerpc ];)
+	set -e; $(foreach py, $(shell py3versions -r), PATH=$$PATH:/sbin:/usr/sbin PYTHONPATH=. $(py) -B tests/run || [ "$(DEB_HOST_ARCH)" = riscv64 ];)
 endif
 
 override_dh_auto_clean:


### PR DESCRIPTION
as uploaded into the focal queue, but still awaiting approval.