### PR TITLE
Optimize packages_for_modalias

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-drivers-common (1:0.9.4) UNRELEASED; urgency=medium
+
+  * Optimize packages_for_modalias by compiling all the Modaliases into one
+    big regexp that can be used to quickly reject most devices.
+
+ -- Michael Hudson-Doyle <michael.hudson@ubuntu.com>  Wed, 01 Dec 2021 09:47:53 +1300
+
 ubuntu-drivers-common (1:0.9.3) jammy; urgency=medium
 
   * UbuntuDrivers/detect.py,


### PR DESCRIPTION
By compiling all the Modaliases into one big regexp that can be used to
quickly reject most devices.