### PR TITLE
Install nvidia-prime in eariler stage

### DIFF
--- a/ubiquity/target-config/31ubuntu_driver_packages
+++ b/ubiquity/target-config/31ubuntu_driver_packages
@@ -17,8 +17,8 @@ for p in `cat $PKGLIST`; do
 done
 
 # Call prime-select, if needed
-if [ -e /run/nvidia_runtimepm_supported ]; then
-    apt-install nvidia-prime
+if grep -q "^nvidia-driver-\|^linux-modules-nvidia-" $PKGLIST; then
+    chroot /target apt install nvidia-prime
     cp /run/nvidia_runtimepm_supported /target/run/nvidia_runtimepm_supported
     rm -f /target/etc/prime-discrete
     chroot /target prime-select on-demand </dev/null


### PR DESCRIPTION
1. Install nvidia-prime during config stage. (LP: #1943816)
2. Make sure the runtimepm and on-demand mode is seperate. (LP:#1942789)

Fix https://github.com/tseliot/ubuntu-drivers-common/issues/64 as well