### PR TITLE
Make sure drm devices are ready

### DIFF
--- a/share/hybrid/Makefile
+++ b/share/hybrid/Makefile
@@ -3,8 +3,8 @@
 PROGRAM = gpu-manager
 PROGRAM_FILES = gpu-manager.c
 CC = gcc
-CFLAGS =-g -Wall $(shell pkg-config --cflags libpci libdrm libkmod) -Ijson-parser json-parser/json.c
-LDFLAGS =$(shell pkg-config --libs libpci libdrm libkmod) -lm
+CFLAGS =-g -Wall $(shell pkg-config --cflags libpci libdrm libkmod libudev) -Ijson-parser json-parser/json.c
+LDFLAGS =$(shell pkg-config --libs libpci libdrm libkmod libudev) -lm
 
 all: build
 


### PR DESCRIPTION
1. In some cases, the DM, gpu-manager will launch earlier than
   drm-uevetns be processed but DM and gpu-manager are usually expect
   related events are there. For example, the GDM using udev (at least
   in amd64) to prefer the specific configurations. (e.g. X or Wayland).
   If the drm-uevents are not there then it will choose the unexpected
   configuration.
2. This patch monitors the uevents and waiting for them be processed.
   Since there are many uevents be queued, we more incline to careful
   drm related only instead of all uevents (also which speed up the boot
   time roughly 300 ms). Thus, if there is a boot_vga device be
   processed then no more wait (because at least, the boot_vga monitor
   should work smoothly)
3. This patch increase the average boot time roughly 300-500 ms but also
   increase the system stabilities.

Launchpad bug: https://bugs.launchpad.net/ubuntu/+source/gdm3/+bug/1958488
gdm upstream bug: https://gitlab.gnome.org/GNOME/gdm/-/issues/763
Debian bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1004131