### PR TITLE
Make sure nvidia-drm rules action processed

### DIFF
--- a/share/hybrid/71-u-d-c-gpu-detection.rules
+++ b/share/hybrid/71-u-d-c-gpu-detection.rules
@@ -5,3 +5,4 @@ ACTION=="add", SUBSYSTEM=="drm", DEVPATH=="*/drm/card*", RUN+="/sbin/u-d-c-print
 
 # Create a file when a module is loaded
 ACTION=="add", SUBSYSTEMS=="pci", DRIVERS=="nvidia", RUN+="/bin/touch /run/u-d-c-nvidia-was-loaded"
+ACTION=="add", SUBSYSTEM=="module", KERNEL=="nvidia_drm", RUN+="/bin/touch /run/u-d-c-nvidia-drm-was-loaded"


### PR DESCRIPTION
This MP is a better solution for LP#1958488.

Verified passed on problematic machine in 1000 times stress.

GDM expects nvidia-drm be loaded to configures wayland or xorg:
```
KERNEL!="nvidia_drm", GOTO="gdm_nvidia_drm_end"
SUBSYSTEM!="module", GOTO="gdm_nvidia_drm_end"
ACTION!="add", GOTO="gdm_nvidia_drm_end"
ATTR{parameters/modeset}!="Y", GOTO="gdm_disable_wayland"
```
In some race condition, the nvidia-drm was load later than gdm.
gpu-manager can cover this case to prevent race condition.