### PR TITLE
fix: local variable 'version' referenced before assignment:

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -920,10 +920,9 @@ def nvidia_desktop_pre_installation_hook(to_install):
         if match:
             try:
                 version = int(match.group(1))
+                with_nvidia_kms = version >= 470
             except ValueError:
                 pass
-            finally:
-                with_nvidia_kms = version >= 470
 
     if with_nvidia_kms:
         set_nvidia_kms(1)


### PR DESCRIPTION
when ValueError happened, the code in finally part will raise UnboundLocalError: local variable 'version' referenced before assignment. So move with_nvidia_kms before except part.