### PR TITLE
removing redundant variable

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -911,7 +911,6 @@ def get_desktop_package_list(apt_cache, sys_path=None, free_only=False, include_
 
 def nvidia_desktop_pre_installation_hook(to_install):
     '''Applies changes that need to happen before installing the NVIDIA drivers'''
-    with_nvidia_kms = False
 
     # Enable KMS if nvidia >= 470
     for package_name in to_install:
@@ -920,12 +919,11 @@ def nvidia_desktop_pre_installation_hook(to_install):
         if match:
             try:
                 version = int(match.group(1))
-                with_nvidia_kms = version >= 470
             except ValueError:
-                pass
-
-    if with_nvidia_kms:
-        set_nvidia_kms(1)
+                continue
+            if version >= 470:
+                set_nvidia_kms(1)
+                return
 
 
 def nvidia_desktop_post_installation_hook():


### PR DESCRIPTION
### Changes done

**nvidia_desktop_pre_installation_hook** contained a `with_nvidia_kms` boolean variable that could be eliminated by some minor refactoring. As only the set of this variable was affected by the inner for loop, we can also `return` as soon as a true is found.

### Rationale

I had an issue with the variable "version" being read without being set, thus raising an `UnboundLocalError`. I fixed it on my machine (and fixed my arguments, since that was what showed the issue), and looked online. It seems to be fixed here, but my local fix seemed slightly better. If it is not, please just delete this and message me telling me what I overlooked.