### PR TITLE
Fix --no-oem option stored in wrong config variable

### DIFF
--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -380,7 +380,7 @@ def greet(config, gpgpu, free_only, package_list, no_oem, **kwargs):
     if package_list:
         config.package_list = package_list
     if no_oem:
-        config.no_oem = install_oem_meta
+        config.install_oem_meta = False
 
 @greet.command()
 @click.argument('driver', nargs=-1)  # add the name argument
@@ -402,7 +402,7 @@ def install(config, **kwargs):
     if kwargs.get('package_list'):
         config.package_list = ''.join(kwargs.get('package_list'))
     if kwargs.get('no_oem'):
-        config.no_oem = kwargs.get('no_oem')
+        config.install_oem_meta = False
 
     if kwargs.get('driver'):
         config.driver_string = ''.join(kwargs.get('driver'))


### PR DESCRIPTION
When ubuntu-drivers is invoked with `--no-oem` as a global option (i.e., `ubuntu-drivers --no-oem list` or `ubuntu-drivers --no-oem install`, the greet function attempts to store its value in the `Config` object.

In the Config object, the name of the attribute is `install_oem_meta` - which defaults to True and should be set to False if the `--no-oem` option is passed.
On the other hand, the parameter that the greet function receives is called `no_oem` (and should be set to True if the `--no-oem` option is passed).

When trying to set the `config.install_oem_meta` field from the `no_oem` variable, we actually tried to read from the `install_oem_meta` parameter (which does not exist) into the `config.no_oem` attribute (which does not exist either).

This resulted in the following exception:

```python
 Traceback (most recent call last):
   File "/usr/bin/ubuntu-drivers", line 383, in greet
     config.no_oem = install_oem_meta
 NameError: name 'install_oem_meta' is not defined
```

Furthermore, we need to negate `no_oem` if we want to store its value in `config.install_oem_meta` - since one denotes the opposite of the other.

Also, the "install" action supports the `--no-oem` option. The install function does not try to read from the wrong variable name so doing `ubuntu-drivers install --no-oem` does not result in an expection. However, the flag is still stored in the wrong attribute of config so the option ended up being ignored completely:

```bash
 # ubuntu-drivers install --no-oem
 Reading package lists... Done
 Building dependency tree... Done
 Reading state information... Done
 The following additional packages will be installed:
 [...]
 oem-somerville-meta
```

Fixed by storing False in the `install_oem_meta` field when `--no-oem` is passed either as a global option or as an option of "install".

This should address the following bug: https://bugs.launchpad.net/ubuntu/+source/ubuntu-drivers-common/+bug/1966413