### PR TITLE
Support installation of libfprint-2-tod-* packages.(issues: #85)

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -538,7 +538,7 @@ options nvidia-drm modeset=%d\n''' % (value)
     kms_fd.close()
 
 
-def system_driver_packages(apt_cache=None, sys_path=None, freeonly=False, include_oem=True):
+def system_driver_packages(apt_cache=None, sys_path=None, freeonly=False, include_oem=True, include_libfprint_tod=True):
     '''Get driver packages that are available for the system.
 
     This calls system_modaliases() to determine the system's hardware and then
@@ -590,6 +590,8 @@ def system_driver_packages(apt_cache=None, sys_path=None, freeonly=False, includ
             if freeonly and not _is_package_free(apt_cache, p):
                 continue
             if not include_oem and fnmatch.fnmatch(p.name, 'oem-*-meta'):
+                continue
+            if not include_libfprint_tod and fnmatch.fnmatch(p.name, 'libfprint-2-tod1-*'):
                 continue
             packages[p.name] = {
                     'modalias': alias,
@@ -917,11 +919,13 @@ def system_device_drivers(apt_cache=None, sys_path=None, freeonly=False):
     return result
 
 
-def get_desktop_package_list(apt_cache, sys_path=None, free_only=False, include_oem=True, driver_string=''):
+def get_desktop_package_list(apt_cache, sys_path=None, free_only=False,
+                             include_oem=True, include_libfprint_tod=True,
+                             driver_string=''):
     '''Return the list of packages that should be installed'''
     packages = system_driver_packages(
         apt_cache, sys_path, freeonly=free_only,
-        include_oem=include_oem)
+        include_oem=include_oem, include_libfprint_tod=include_libfprint_tod)
     packages = auto_install_filter(packages, driver_string)
     if not packages:
         logging.debug('No drivers found for installation.')
@@ -1137,7 +1141,7 @@ def auto_install_filter(packages, drivers_str=''):
     '''
     # any package which matches any of those globs will be accepted
     whitelist = ['bcmwl*', 'pvr-omap*', 'virtualbox-guest*', 'nvidia-*',
-                 'open-vm-tools*', 'oem-*-meta']
+                 'open-vm-tools*', 'oem-*-meta', 'libfprint-2-tod1-*']
 
     # If users specify a driver, use gpgpu_install_filter()
     if drivers_str:

--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -39,6 +39,7 @@ class Config(object):
         self.package_list = ''
         self.install_oem_meta = True
         self.driver_string = ''
+        self.install_libfprint_tod = True
 
 pass_config = click.make_pass_decorator(Config, ensure=True)
 
@@ -54,7 +55,8 @@ def command_list(args):
         return 1
 
     packages = UbuntuDrivers.detect.system_driver_packages(apt_cache=cache,
-        sys_path=sys_path, freeonly=args.free_only, include_oem=args.install_oem_meta)
+        sys_path=sys_path, freeonly=args.free_only, include_oem=args.install_oem_meta,
+        include_libfprint_tod=args.install_libfprint_tod)
 
     for package in packages:
         try:
@@ -172,6 +174,7 @@ def command_install(args):
 
     to_install = UbuntuDrivers.detect.get_desktop_package_list(cache, sys_path,
         free_only=args.free_only, include_oem=args.install_oem_meta,
+        include_libfprint_tod=args.install_libfprint_tod,
         driver_string=args.driver_string)
 
     if not to_install:
@@ -312,7 +315,8 @@ def command_debug(args):
 
     depcache = apt_pkg.DepCache(cache)
     packages = UbuntuDrivers.detect.system_driver_packages(
-        cache, sys_path, freeonly=args.free_only, include_oem=args.install_oem_meta)
+        cache, sys_path, freeonly=args.free_only, include_oem=args.install_oem_meta,
+        include_libfprint_tod=args.install_libfprint_tod)
     auto_packages = UbuntuDrivers.detect.auto_install_filter(packages)
 
     print('=== modaliases in the system ===')
@@ -370,8 +374,9 @@ def command_debug(args):
 @click.option('--free-only', is_flag=True, help='Only consider free packages')
 @click.option('--package-list', nargs=1, metavar='PATH', help='Create file with list of installed packages (in install mode)')
 @click.option('--no-oem', is_flag=True, default=False, show_default=True, metavar='install_oem_meta', help='Do not include OEM enablement packages (these enable an external archive)')
+@click.option('--no-tod', is_flag=True, default=False, show_default=True, metavar='install_libfprint_tod', help='Do not include libfprint tod driver packages')
 @pass_config
-def greet(config, gpgpu, free_only, package_list, no_oem, **kwargs):
+def greet(config, gpgpu, free_only, package_list, no_oem, no_tod, **kwargs):
     if gpgpu:
         click.echo('This is gpgpu mode')
         config.gpu = True
@@ -381,6 +386,8 @@ def greet(config, gpgpu, free_only, package_list, no_oem, **kwargs):
         config.package_list = package_list
     if no_oem:
         config.install_oem_meta = False
+    if no_tod:
+        config.install_libfprint_tod = False
 
 @greet.command()
 @click.argument('driver', nargs=-1)  # add the name argument
@@ -389,6 +396,7 @@ def greet(config, gpgpu, free_only, package_list, no_oem, **kwargs):
 @click.option('--free-only', is_flag=True, help='Only consider free packages')
 @click.option('--package-list', nargs=1, metavar='PATH', help='Create file with list of installed packages (in install mode)')
 @click.option('--no-oem', is_flag=True, metavar='install_oem_meta', help='Do not include OEM enablement packages (these enable an external archive)')
+@click.option('--no-tod', is_flag=True, metavar='install_libfprint_tod', help='Do not include libfprint tod driver packages')
 @pass_config
 def install(config, **kwargs):
     '''Install a driver [driver[:version][,driver[:version]]]'''
@@ -403,6 +411,8 @@ def install(config, **kwargs):
         config.package_list = ''.join(kwargs.get('package_list'))
     if kwargs.get('no_oem'):
         config.install_oem_meta = False
+    if kwargs.get('no_tod'):
+        config.install_libfprint_tod = False
 
     if kwargs.get('driver'):
         config.driver_string = ''.join(kwargs.get('driver'))
@@ -452,7 +462,8 @@ def list(config, **kwargs):
         packages = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache, sys_path)
     else:
         packages = UbuntuDrivers.detect.system_driver_packages(apt_cache=cache,
-            sys_path=sys_path, freeonly=config.free_only, include_oem=config.install_oem_meta)
+            sys_path=sys_path, freeonly=config.free_only, include_oem=config.install_oem_meta,
+            include_libfprint_tod=config.install_libfprint_tod)
 
     if kwargs.get('recommended'):
         if kwargs.get('gpgpu'):


### PR DESCRIPTION
Add the new option 'no-tod', it could install libfprint-2-tod1-* packages by default, with '--no-tod' it will ignore these libfprint-2-tod1-* packages.
