### PR TITLE
Add boradcom-sta-dkms to allowlist.

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -1180,7 +1180,7 @@ def auto_install_filter(packages, drivers_str=''):
     '''
     # any package which matches any of those globs will be accepted
     whitelist = ['bcmwl*', 'pvr-omap*', 'virtualbox-guest*', 'nvidia-*',
-                 'open-vm-tools*', 'oem-*-meta']
+                 'open-vm-tools*', 'oem-*-meta', 'broadcom-sta-dkms']
 
     # If users specify a driver, use gpgpu_install_filter()
     if drivers_str:


### PR DESCRIPTION
In Lunar it was identified that both bcmwl and broadcom-sta-dkms are identical and maintained in the archive twice. They were merged, taking the Debian name as the new default one. However, allowlist was forgotten to be updated in ubuntu-drivers to actually offer default install of broadcom-sta-dkms.

LP: #2013236