### PR TITLE
Support the installation of MIPI camera out of tree drivers

### DIFF
--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -39,6 +39,7 @@ class Config(object):
         self.package_list = ''
         self.install_oem_meta = True
         self.driver_string = ''
+        self.install_mipi_cam = True
 
 pass_config = click.make_pass_decorator(Config, ensure=True)
 
@@ -54,7 +55,8 @@ def command_list(args):
         return 1
 
     packages = UbuntuDrivers.detect.system_driver_packages(apt_cache=cache,
-        sys_path=sys_path, freeonly=args.free_only, include_oem=args.install_oem_meta)
+        sys_path=sys_path, freeonly=args.free_only, include_oem=args.install_oem_meta,
+        include_mipi_cam=arg.install_mipi_cam)
 
     for package in packages:
         try:
@@ -172,6 +174,7 @@ def command_install(args):
 
     to_install = UbuntuDrivers.detect.get_desktop_package_list(cache, sys_path,
         free_only=args.free_only, include_oem=args.install_oem_meta,
+        include_mipi_cam=args.install_mipi_cam,
         driver_string=args.driver_string)
 
     if not to_install:
@@ -318,7 +321,8 @@ def command_debug(args):
 
     depcache = apt_pkg.DepCache(cache)
     packages = UbuntuDrivers.detect.system_driver_packages(
-        cache, sys_path, freeonly=args.free_only, include_oem=args.install_oem_meta)
+        cache, sys_path, freeonly=args.free_only, include_oem=args.install_oem_meta,
+        include_mipi_cam=args.install_mipi_cam)
     auto_packages = UbuntuDrivers.detect.auto_install_filter(packages)
 
     print('=== modaliases in the system ===')
@@ -376,8 +380,9 @@ def command_debug(args):
 @click.option('--free-only', is_flag=True, help='Only consider free packages')
 @click.option('--package-list', nargs=1, metavar='PATH', help='Create file with list of installed packages (in install mode)')
 @click.option('--no-oem', is_flag=True, default=False, show_default=True, metavar='install_oem_meta', help='Do not include OEM enablement packages (these enable an external archive)')
+@click.option('--no-mipi', is_flag=True, default=False, show_default=True, metavar='install_mipi_cam', help='Do not include MIPI camera kernel packages')
 @pass_config
-def greet(config, gpgpu, free_only, package_list, no_oem, **kwargs):
+def greet(config, gpgpu, free_only, package_list, no_oem, no_mipi, **kwargs):
     if gpgpu:
         click.echo('This is gpgpu mode')
         config.gpu = True
@@ -387,6 +392,8 @@ def greet(config, gpgpu, free_only, package_list, no_oem, **kwargs):
         config.package_list = package_list
     if no_oem:
         config.install_oem_meta = False
+    if no_mipi:
+        config.install_mipi_cam = False
 
 @greet.command()
 @click.argument('driver', nargs=-1)  # add the name argument
@@ -395,6 +402,7 @@ def greet(config, gpgpu, free_only, package_list, no_oem, **kwargs):
 @click.option('--free-only', is_flag=True, help='Only consider free packages')
 @click.option('--package-list', nargs=1, metavar='PATH', help='Create file with list of installed packages (in install mode)')
 @click.option('--no-oem', is_flag=True, metavar='install_oem_meta', help='Do not include OEM enablement packages (these enable an external archive)')
+@click.option('--no-mipi', is_flag=True, default=False, show_default=True, metavar='install_mipi_cam', help='Do not include MIPI camera kernel packages')
 @pass_config
 def install(config, **kwargs):
     '''Install a driver [driver[:version][,driver[:version]]]'''
@@ -409,6 +417,8 @@ def install(config, **kwargs):
         config.package_list = ''.join(kwargs.get('package_list'))
     if kwargs.get('no_oem'):
         config.install_oem_meta = False
+    if kwargs.get('no_mipi'):
+        config.install_mipi_cam = False
 
     if kwargs.get('driver'):
         config.driver_string = ''.join(kwargs.get('driver'))
@@ -458,7 +468,8 @@ def list(config, **kwargs):
         packages = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache, sys_path)
     else:
         packages = UbuntuDrivers.detect.system_driver_packages(apt_cache=cache,
-            sys_path=sys_path, freeonly=config.free_only, include_oem=config.install_oem_meta)
+            sys_path=sys_path, freeonly=config.free_only, include_oem=config.install_oem_meta,
+            include_mipi_cam=config.install_mipi_cam)
 
     if kwargs.get('recommended'):
         if kwargs.get('gpgpu'):


### PR DESCRIPTION
Support to install MIPI camera out of tree modules including

- linux-modules-ipu6*
- linux-modules-ivsc*
- linux-modules-usbio*